### PR TITLE
Add stylish web UI for media converter

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,7 +165,11 @@ def time_to_seconds(time_str):
 def index():
     """Hauptseite"""
     ffmpeg_available = check_ffmpeg()
-    return render_template('converter.html', ffmpeg_available=ffmpeg_available)
+    return render_template(
+        'converter.html',
+        ffmpeg_available=ffmpeg_available,
+        SUPPORTED_OUTPUT_FORMATS=SUPPORTED_OUTPUT_FORMATS
+    )
 
 @app.route('/convert', methods=['POST'])
 def convert_file():

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,49 @@
+const form = document.getElementById('convert-form');
+const progressSection = document.getElementById('progress-section');
+const downloadSection = document.getElementById('download-section');
+const progressBar = document.getElementById('progress');
+const progressText = document.getElementById('progress-text');
+const downloadLink = document.getElementById('download-link');
+
+let currentTaskId = null;
+
+form?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const formData = new FormData(form);
+
+    progressSection.classList.remove('hidden');
+    downloadSection.classList.add('hidden');
+    progressBar.style.width = '0%';
+    progressText.textContent = '0%';
+
+    const response = await fetch('/convert', {
+        method: 'POST',
+        body: formData
+    });
+    const data = await response.json();
+
+    if (data.task_id) {
+        currentTaskId = data.task_id;
+        checkStatus();
+    } else if (data.error) {
+        alert(data.error);
+    }
+});
+
+async function checkStatus() {
+    if (!currentTaskId) return;
+    const res = await fetch(`/status/${currentTaskId}`);
+    const data = await res.json();
+    if (data.status === 'completed') {
+        progressBar.style.width = '100%';
+        progressText.textContent = 'Fertig';
+        downloadLink.href = `/download/${currentTaskId}`;
+        downloadSection.classList.remove('hidden');
+    } else if (data.status === 'error') {
+        alert(data.error || 'Ein Fehler ist aufgetreten');
+    } else {
+        progressBar.style.width = `${data.progress || 0}%`;
+        progressText.textContent = `${data.progress || 0}%`;
+        setTimeout(checkStatus, 1000);
+    }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,89 @@
+body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+    color: #333;
+}
+
+.container {
+    max-width: 600px;
+    margin: 80px auto;
+    padding: 40px;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+
+header h1 {
+    margin: 0;
+    font-size: 2.5rem;
+    font-weight: 600;
+    text-align: center;
+    color: #111;
+}
+
+header p {
+    text-align: center;
+    color: #666;
+    margin-bottom: 40px;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 500;
+}
+
+input[type="file"],
+select {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    background: #f9f9f9;
+}
+
+.btn {
+    display: inline-block;
+    padding: 12px 24px;
+    background: #007aff;
+    color: white;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    text-decoration: none;
+    font-size: 1rem;
+}
+
+.btn:hover {
+    background: #0051a8;
+}
+
+.progress-bar {
+    width: 100%;
+    height: 8px;
+    background: #eee;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 8px;
+}
+
+.progress-bar #progress {
+    height: 100%;
+    background: #007aff;
+    width: 0;
+    transition: width 0.3s ease;
+}
+
+.hidden {
+    display: none;
+}
+
+.error {
+    color: #b00020;
+    margin-bottom: 20px;
+}

--- a/templates/converter.html
+++ b/templates/converter.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Media Converter</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<div class="container">
+    <header>
+        <h1>Media Converter</h1>
+        <p>Konvertiere Videos und Audios in eleganter Apple-Ästhetik.</p>
+    </header>
+
+    <section id="upload-section">
+        {% if not ffmpeg_available %}
+        <div class="error">FFmpeg ist nicht installiert. Bitte installiere FFmpeg, um den Konverter zu verwenden.</div>
+        {% else %}
+        <form id="convert-form">
+            <div class="form-group">
+                <label for="media_file">Datei auswählen</label>
+                <input type="file" id="media_file" name="media_file" required>
+            </div>
+            <div class="form-group">
+                <label for="output_format">Ausgabeformat</label>
+                <select id="output_format" name="output_format">
+                    {% for fmt, data in SUPPORTED_OUTPUT_FORMATS.items() %}
+                    <option value="{{ fmt }}">{{ data['name'] }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="quality">Qualität</label>
+                <select id="quality" name="quality">
+                    <option value="high">Hoch</option>
+                    <option value="medium" selected>Mittel</option>
+                    <option value="low">Niedrig</option>
+                </select>
+            </div>
+            <button type="submit" class="btn">Konvertieren</button>
+        </form>
+        {% endif %}
+    </section>
+
+    <section id="progress-section" class="hidden">
+        <div class="progress-bar">
+            <div id="progress" style="width:0%"></div>
+        </div>
+        <p id="progress-text">0%</p>
+    </section>
+
+    <section id="download-section" class="hidden">
+        <a id="download-link" class="btn" href="#">Download</a>
+    </section>
+</div>
+<script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sleek HTML/CSS/JS front‑end in `templates` and `static`
- expose `SUPPORTED_OUTPUT_FORMATS` to the template

## Testing
- `python3 -m py_compile app.py`
- `pip install flask`
- `python app.py` *(fails without FFmpeg but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_684071699c408328b499fd15569db2bb